### PR TITLE
時計エラーの修正

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,3 +16,4 @@
 //= require activestorage
 //= require data-confirm-modal
 //= require_tree .
+//= stub 'ios'

--- a/app/assets/javascripts/ios.js
+++ b/app/assets/javascripts/ios.js
@@ -22,7 +22,7 @@ $(function(){
     let input = $(this).val();
     $('#ios_student_id-checkin').val(input);
     $('#ios_student_id-checkout').val(input);
-    console.log(input);
+    console.log(document.querySelector('#ios_student_id-checkin').value);
     $.ajax({
       type: 'GET',
       url: '/students',
@@ -30,6 +30,7 @@ $(function(){
       dataType: 'json'
     }).done(function(students){
       if (students.length > 0) {
+        console.log(students);
         document.querySelector('#ios_student_name').textContent = students[0].student_name;
         document.querySelector('#ios_student_name').value = students[0].student_name;
         $.ajax({

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -1,7 +1,7 @@
 class StudentsController < ApplicationController
     def index
     #    @students=Student.where(id: params[:ios_student_id].to_i)
-    @students=Student.all
+        @students=Student.all
     end
     def new
         @student = Student.new

--- a/app/views/ios/new.html.haml
+++ b/app/views/ios/new.html.haml
@@ -14,3 +14,4 @@
         =f.hidden_field :student_id,id: "ios_student_id-checkout"
       = f.submit "退室する  ", id: "ios_exit",class: "fas ios_button"
     = link_to 'キャンセル', new_io_path, id:'ios_cancel', class: 'fas ios_button btn'
+= javascript_include_tag 'ios.js'

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -11,4 +11,4 @@ Rails.application.config.assets.paths << Rails.root.join('node_modules')
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
-# Rails.application.config.assets.precompile += %w( admin.js admin.css )
+Rails.application.config.assets.precompile += %w( ios.js )


### PR DESCRIPTION
# What
ios.jsをios/newのみで読み込ませるようにした
# Why
他のページでも時計を表示するJSが毎秒発火して参照先がないとのエラーが発生するため